### PR TITLE
display properly README at markdown format on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version='0.4.0',
     description="pyup-django checks your installed dependencies for known security vulnerabilities and displays them in the admin area.",
     long_description=readme,
+    long_description_content_type="text/markdown",
     author="pyup.io",
     author_email='support@pyup.io',
     url='https://github.com/pyupio/pyup-django',


### PR DESCRIPTION
Since few months pypi.org can deal properly with README at markdown format.

This pull requests specify to pypi to use markdown format.